### PR TITLE
fix(store/torbox): use POST for checkcached

### DIFF
--- a/store/torbox/torrent.go
+++ b/store/torbox/torrent.go
@@ -48,17 +48,18 @@ type CheckTorrentsCachedData []CheckTorrentsCachedDataItem
 
 type CheckTorrentsCachedParams struct {
 	Ctx
-	Hashes    []string
-	ListFiles bool
+	Hashes    []string `json:"hashes"`
+	ListFiles bool     `json:"-"`
 }
 
 func (c APIClient) CheckTorrentsCached(params *CheckTorrentsCachedParams) (APIResponse[CheckTorrentsCachedData], error) {
-	form := &url.Values{"hash": params.Hashes}
-	form.Add("format", "list")
-	form.Add("list_files", strconv.FormatBool(params.ListFiles))
-	params.Form = form
+	params.JSON = params
+	params.Query = &url.Values{
+		"format":     {"list"},
+		"list_files": {strconv.FormatBool(params.ListFiles)},
+	}
 	response := &Response[CheckTorrentsCachedData]{}
-	res, err := c.Request("GET", "/v1/api/torrents/checkcached", params, response)
+	res, err := c.Request("POST", "/v1/api/torrents/checkcached", params, response)
 	return newAPIResponse(res, response.Data, response.Detail), err
 }
 


### PR DESCRIPTION
Due to TorBox's recent changes to rate limiting by API key, sending multiple chunked GET requests for cache checking doesn't make much sense as it leads to ratelimits. checkcached supports POST with hashes in the JSON body, so we can send all hashes in a single request instead of chunking into batches of 100 concurrent GETs.

Via TorBox's own api docs; it can handle up to nearly unlimited- test batches of 5000 processed within a second.
