### PR TITLE
feat(db): add PostgreSQL read replica support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -410,6 +410,7 @@ type Config struct {
 	PullPeerURL                 string
 	RedisURI                    string
 	DatabaseURI                 string
+	DatabaseReadReplicaURI      string
 	Feature                     FeatureConfig
 	Version                     string
 	LandingPage                 string
@@ -660,6 +661,7 @@ var config = func() Config {
 		PullPeerURL:                 pullPeerUrl,
 		RedisURI:                    getEnv("STREMTHRU_REDIS_URI"),
 		DatabaseURI:                 databaseUri,
+		DatabaseReadReplicaURI:      getEnv("STREMTHRU_DATABASE_READ_REPLICA_URI"),
 		Feature:                     feature,
 		Version:                     "0.97.1", // x-release-please-version
 		LandingPage:                 getEnv("STREMTHRU_LANDING_PAGE"),
@@ -693,6 +695,7 @@ var HasPeer = config.HasPeer
 var PullPeerURL = config.PullPeerURL
 var RedisURI = config.RedisURI
 var DatabaseURI = config.DatabaseURI
+var DatabaseReadReplicaURI = config.DatabaseReadReplicaURI
 var Feature = config.Feature
 var Version = config.Version
 var LandingPage = config.LandingPage

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -21,6 +21,8 @@ type DB struct {
 }
 
 var db = &DB{}
+var readDB *sql.DB   // read replica, nil when not configured
+var readDBClose func() // cleanup function for read replica
 var Dialect DBDialect
 
 var BooleanFalse string
@@ -103,11 +105,19 @@ var getExec = func(db Executor) dbExec {
 var Exec = getExec(db)
 
 func Query(query string, args ...any) (*sql.Rows, error) {
-	return db.Query(adaptQuery(query), args...)
+	q := adaptQuery(query)
+	if readDB != nil {
+		return readDB.Query(q, args...)
+	}
+	return db.Query(q, args...)
 }
 
 func QueryRow(query string, args ...any) *sql.Row {
-	return db.QueryRow(adaptQuery(query), args...)
+	q := adaptQuery(query)
+	if readDB != nil {
+		return readDB.QueryRow(q, args...)
+	}
+	return db.QueryRow(q, args...)
 }
 
 type dbExecutor struct{}
@@ -169,9 +179,18 @@ func Ping() {
 		log.Fatalf("[db] failed to ping: %v\n", err)
 	}
 	one := 0
-	row := QueryRow("SELECT 1")
+	row := db.QueryRow(adaptQuery("SELECT 1"))
 	if err := row.Scan(&one); err != nil {
 		log.Fatalf("[db] failed to query: %v\n", err)
+	}
+	if readDB != nil {
+		if err := readDB.Ping(); err != nil {
+			log.Fatalf("[db] failed to ping read replica: %v\n", err)
+		}
+		row := readDB.QueryRow(adaptQuery("SELECT 1"))
+		if err := row.Scan(&one); err != nil {
+			log.Fatalf("[db] failed to query read replica: %v\n", err)
+		}
 	}
 }
 
@@ -197,10 +216,33 @@ func Open() *DB {
 
 	db.URI = connUri
 
+	if config.DatabaseReadReplicaURI != "" {
+		replicaUri, err := ParseConnectionURI(config.DatabaseReadReplicaURI)
+		if err != nil {
+			log.Fatalf("[db] failed to parse read replica uri: %v\n", err)
+		}
+		if replicaUri.Dialect != DBDialectPostgres {
+			log.Fatalf("[db] read replica only supports postgresql\n")
+		}
+		pool, err := pgxpool.New(context.Background(), replicaUri.DSN())
+		if err != nil {
+			log.Fatalf("[db] failed to create read replica connection pool: %v\n", err)
+		}
+		readDB = stdlib.OpenDBFromPool(pool)
+		readDBClose = func() {
+			readDB.Close()
+			pool.Close()
+		}
+		log.Println("[db] read replica enabled")
+	}
+
 	return db
 }
 
 func Close() error {
+	if readDBClose != nil {
+		readDBClose()
+	}
 	err := db.Close()
 	if db.onClose != nil {
 		err = errors.Join(err, db.onClose())


### PR DESCRIPTION
## Summary

- Add optional read replica routing via `STREMTHRU_DATABASE_READ_REPLICA_URI` env var
- All read queries (`Query`, `QueryRow`) route to replica when configured
- All writes (`Exec`, `Begin`, advisory locks) stay on primary
- Uses `pgxpool` for the replica connection, matching the primary's pattern

## Context

For high-traffic instances, the database read path is the main bottleneck — particularly `magnet_cache.GetByHashes()` and `torrent_stream.GetFilesByHashes()` which run on every cache check with unbounded IN clauses and JSON aggregation.

This change enables deploying a PostgreSQL read replica to offload those reads, while keeping writes on the primary for consistency.

## How it works

The routing is transparent — all 47 files that import `internal/db` call package-level functions (`db.Query`, `db.QueryRow`, `db.Exec`) which now check for a replica connection:

```go
func Query(query string, args ...any) (*sql.Rows, error) {
    q := adaptQuery(query)
    if readDB != nil {
        return readDB.Query(q, args...)
    }
    return db.Query(q, args...)
}
```

Transactions (`Begin()`) always use the primary, so transaction-scoped reads (via `tx.Query`) correctly stay on the writer — no read-after-write inconsistencies.

When `STREMTHRU_DATABASE_READ_REPLICA_URI` is unset, behavior is identical to current — `readDB` stays nil and all queries go to the primary.

## Test plan

- [ ] `go build --tags "fts5"` compiles
- [ ] Existing tests pass (`make test`)
- [ ] Without env var: identical behavior to current (no replica, all queries on primary)
- [ ] With env var: reads on replica, writes on primary
- [ ] Startup validates replica connection (ping + SELECT 1)
- [ ] Graceful shutdown closes replica pool before primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)