### PR TITLE
feat(cache): Redis-backed caching for hot-path DB queries

### DIFF
--- a/internal/magnet_cache/db.go
+++ b/internal/magnet_cache/db.go
@@ -37,7 +37,23 @@ func (mc MagnetCache) IsStale() bool {
 	return mc.ModifiedAt.Before(time.Now().Add(-staleTime))
 }
 
-func GetByHashes(store store.StoreCode, hashes []string, sid string) ([]MagnetCache, error) {
+type magnetCacheRow struct {
+	Store      store.StoreCode `json:"s"`
+	Hash       string          `json:"h"`
+	IsCached   bool            `json:"c"`
+	ModifiedAt db.Timestamp    `json:"m"`
+}
+
+var magnetCacheRowCache = cache.NewCache[magnetCacheRow](&cache.CacheConfig{
+	Name:     "magnet_cache:row",
+	Lifetime: 2 * time.Minute,
+})
+
+func magnetCacheKey(storeCode store.StoreCode, hash string) string {
+	return string(storeCode) + ":" + hash
+}
+
+func GetByHashes(storeCode store.StoreCode, hashes []string, sid string) ([]MagnetCache, error) {
 	if len(hashes) == 0 {
 		return []MagnetCache{}, nil
 	}
@@ -47,54 +63,88 @@ func GetByHashes(store store.StoreCode, hashes []string, sid string) ([]MagnetCa
 		return nil, err
 	}
 
-	args_len := len(hashes) + 1
-	if sid != "" {
-		args_len += 1
-	}
-	arg_idx := 0
-	args := make([]any, args_len)
-
-	query := "SELECT store, hash, is_cached, modified_at FROM " + TableName
-	if sid != "" {
-		query += " LEFT JOIN " + torrent_stream.TableName + " ON " + TableName + ".hash = " + torrent_stream.TableName + ".h WHERE (is_cached = " + db.BooleanFalse + " OR " + torrent_stream.TableName + ".sid IN (?, '*')) AND"
-		args[arg_idx] = sid
-		arg_idx += 1
-	} else {
-		query += " WHERE"
+	// Try cache first for each hash
+	uncachedHashes := make([]string, 0, len(hashes))
+	cachedRows := map[string]magnetCacheRow{}
+	for _, hash := range hashes {
+		var row magnetCacheRow
+		if magnetCacheRowCache.Get(magnetCacheKey(storeCode, hash), &row) {
+			cachedRows[hash] = row
+		} else {
+			uncachedHashes = append(uncachedHashes, hash)
+		}
 	}
 
-	args[arg_idx] = store
-	arg_idx += 1
-	hashPlaceholders := make([]string, len(hashes))
-	for i, hash := range hashes {
-		hashPlaceholders[i] = "?"
-		args[arg_idx+i] = hash
-	}
+	// Query DB for uncached hashes
+	if len(uncachedHashes) > 0 {
+		args := make([]any, 1+len(uncachedHashes))
+		args[0] = storeCode
+		hashPlaceholders := make([]string, len(uncachedHashes))
+		for i, hash := range uncachedHashes {
+			hashPlaceholders[i] = "?"
+			args[1+i] = hash
+		}
 
-	query += " store = ? AND hash IN (" + strings.Join(hashPlaceholders, ",") + ")"
+		query := "SELECT store, hash, is_cached, modified_at FROM " + TableName + " WHERE store = ? AND hash IN (" + strings.Join(hashPlaceholders, ",") + ")"
 
-	rows, err := db.Query(query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	mcs := []MagnetCache{}
-	for rows.Next() {
-		smc := MagnetCache{}
-		if err := rows.Scan(&smc.Store, &smc.Hash, &smc.IsCached, &smc.ModifiedAt); err != nil {
+		rows, err := db.Query(query, args...)
+		if err != nil {
 			return nil, err
 		}
-		if files, ok := filesByHash[smc.Hash]; ok && len(files) > 0 {
-			smc.Files = files
+		defer rows.Close()
+
+		for rows.Next() {
+			var row magnetCacheRow
+			if err := rows.Scan(&row.Store, &row.Hash, &row.IsCached, &row.ModifiedAt); err != nil {
+				return nil, err
+			}
+			cachedRows[row.Hash] = row
+			magnetCacheRowCache.Add(magnetCacheKey(storeCode, row.Hash), row)
 		}
-		mcs = append(mcs, smc)
+
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
 	}
 
-	if err := rows.Err(); err != nil {
-		return nil, err
+	// Build result, applying sid filter if needed
+	mcs := []MagnetCache{}
+	for _, hash := range hashes {
+		row, ok := cachedRows[hash]
+		if !ok {
+			continue
+		}
+
+		// When sid is set, skip cached items that don't have matching files
+		if sid != "" && row.IsCached {
+			files, hasFiles := filesByHash[hash]
+			if !hasFiles || !filesMatchSid(files, sid) {
+				continue
+			}
+		}
+
+		mc := MagnetCache{
+			Store:      row.Store,
+			Hash:       row.Hash,
+			IsCached:   row.IsCached,
+			ModifiedAt: row.ModifiedAt,
+		}
+		if files, ok := filesByHash[hash]; ok && len(files) > 0 {
+			mc.Files = files
+		}
+		mcs = append(mcs, mc)
 	}
+
 	return mcs, nil
+}
+
+func filesMatchSid(files torrent_stream.Files, sid string) bool {
+	for _, f := range files {
+		if f.SId == sid || f.SId == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 var touchSkipCount atomic.Int64
@@ -138,6 +188,7 @@ func Touch(storeCode store.StoreCode, hash string, files torrent_stream.Files, i
 			return
 		}
 		prevIsCachedCache.Add(cacheKey, isCached)
+		magnetCacheRowCache.Remove(cacheKey)
 	}
 	if !skipFileTracking {
 		torrent_stream.TrackFiles(storeCode, map[string]torrent_stream.Files{hash: files})
@@ -216,6 +267,7 @@ func BulkTouch(storeCode store.StoreCode, filesByHash map[string]torrent_stream.
 		} else {
 			for _, key := range hitCacheKeys {
 				prevIsCachedCache.Add(key, true)
+				magnetCacheRowCache.Remove(key)
 			}
 		}
 	}
@@ -232,6 +284,7 @@ func BulkTouch(storeCode store.StoreCode, filesByHash map[string]torrent_stream.
 		} else {
 			for _, key := range missCacheKeys {
 				prevIsCachedCache.Add(key, false)
+				magnetCacheRowCache.Remove(key)
 			}
 		}
 	}

--- a/internal/torrent_stream/db.go
+++ b/internal/torrent_stream/db.go
@@ -333,6 +333,11 @@ func GetFile(hash string, sid string) (*File, error) {
 	return &file, nil
 }
 
+var filesCache = cache.NewCache[Files](&cache.CacheConfig{
+	Name:     "torrent_stream:files",
+	Lifetime: 5 * time.Minute,
+})
+
 func GetFilesByHashes(hashes []string) (map[string]Files, error) {
 	byHash := map[string]Files{}
 
@@ -340,9 +345,25 @@ func GetFilesByHashes(hashes []string) (map[string]Files, error) {
 		return byHash, nil
 	}
 
-	args := make([]any, len(hashes))
-	hashPlaceholders := make([]string, len(hashes))
-	for i, hash := range hashes {
+	uncachedHashes := make([]string, 0, len(hashes))
+	for _, hash := range hashes {
+		var files Files
+		if filesCache.Get(hash, &files) {
+			if len(files) > 0 {
+				byHash[hash] = files
+			}
+			continue
+		}
+		uncachedHashes = append(uncachedHashes, hash)
+	}
+
+	if len(uncachedHashes) == 0 {
+		return byHash, nil
+	}
+
+	args := make([]any, len(uncachedHashes))
+	hashPlaceholders := make([]string, len(uncachedHashes))
+	for i, hash := range uncachedHashes {
 		args[i] = hash
 		hashPlaceholders[i] = "?"
 	}
@@ -353,6 +374,7 @@ func GetFilesByHashes(hashes []string) (map[string]Files, error) {
 	}
 	defer rows.Close()
 
+	foundHashes := map[string]bool{}
 	for rows.Next() {
 		hash := ""
 		files := Files{}
@@ -360,15 +382,28 @@ func GetFilesByHashes(hashes []string) (map[string]Files, error) {
 			return nil, err
 		}
 		byHash[hash] = files
+		filesCache.Add(hash, files)
+		foundHashes[hash] = true
 	}
 
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+
+	// Cache misses too so we don't re-query for unknown hashes
+	for _, hash := range uncachedHashes {
+		if !foundHashes[hash] {
+			filesCache.Add(hash, Files{})
+		}
+	}
+
 	return byHash, nil
 }
 
 func TrackFiles(storeCode store.StoreCode, filesByHash map[string]Files) {
+	for hash := range filesByHash {
+		filesCache.Remove(hash)
+	}
 	items := []InsertData{}
 	for hash, files := range filesByHash {
 		shouldIgnoreFiles := storeCode == store.StoreCodePremiumize && !files.HasVideo()


### PR DESCRIPTION
## Summary

- Adds per-hash caching to `torrent_stream.GetFilesByHashes()` and `magnet_cache.GetByHashes()` — the two most frequently called DB queries in the check-magnet hot path
- Uses `cache.NewCache` which auto-routes to Redis when `STREMTHRU_REDIS_URI` is set, or falls back to in-memory LRU otherwise
- Cache misses are also cached to avoid re-querying for unknown hashes
- Invalidation on writes (`TrackFiles`, `Touch`, `BulkTouch`)

### Details

**torrent_stream.GetFilesByHashes():**
- 5-minute TTL per-hash cache
- Only queries DB for hashes not found in cache
- Caches empty results (misses) to prevent repeated DB lookups for hashes with no files
- Cache entries invalidated when `TrackFiles()` writes new file data

**magnet_cache.GetByHashes():**
- 2-minute TTL per-hash cache for `(store, hash) → {is_cached, modified_at}` rows
- Removes the `LEFT JOIN torrent_stream` from the SQL query — sid filtering is done at the application level using the already-fetched files data, making the query simpler and more cacheable
- Cache entries invalidated on `Touch()` and `BulkTouch()` when cache status changes

### Impact

On a public instance handling concurrent cache check requests, these two queries account for the bulk of DB reads. With Redis caching, repeated checks for the same hashes (common when multiple users search for the same content) hit Redis instead of PostgreSQL, significantly reducing DB load.

## Test plan

- [ ] Verify `go build --tags "fts5"` compiles cleanly
- [ ] Test without `STREMTHRU_REDIS_URI` — behavior identical to current (uses in-memory LRU fallback)
- [ ] Test with `STREMTHRU_REDIS_URI` — cache check responses served from Redis on repeated queries
- [ ] Verify cache invalidation: after adding a torrent (Touch/TrackFiles), subsequent cache checks reflect the updated state

🤖 Generated with [Claude Code](https://claude.com/claude-code)