### PR TITLE
fix(torbox/torrent): fall back to the Torbox torrent name when it contains more metadata than filename

### DIFF
--- a/store/torbox/torrent.go
+++ b/store/torbox/torrent.go
@@ -38,6 +38,9 @@ type CheckTorrentsCachedDataItem struct {
 func (t CheckTorrentsCachedDataItem) GetName() string {
 	if len(t.Files) > 0 {
 		if _, rootFolder := util.RemoveRootFolderFromPath(t.Files[0].Name); rootFolder != "" {
+			if len(t.Name) > len(rootFolder) {
+				return t.Name
+			}
 			return rootFolder
 		}
 	}
@@ -203,6 +206,9 @@ type Torrent struct {
 func (t Torrent) GetName() string {
 	if len(t.Files) > 0 {
 		if _, rootFolder := util.RemoveRootFolderFromPath(t.Files[0].Name); rootFolder != "" {
+			if len(t.Name) > len(rootFolder) {
+				return t.Name
+			}
 			return rootFolder
 		}
 	}


### PR DESCRIPTION
In cases a filename is too generic, such as "Movie Title.mkv", and has no metadata to parse, fall back to torrent name provided by Torbox if that name is longer than file name.

For issue #513