### PR TITLE
Queue media info probe from /v0/store/link/generate for TorBox

### DIFF
--- a/internal/endpoint/store.go
+++ b/internal/endpoint/store.go
@@ -16,10 +16,9 @@ import (
 	store_util "github.com/MunifTanjim/stremthru/internal/store/util"
 	store_video "github.com/MunifTanjim/stremthru/internal/store/video"
 	"github.com/MunifTanjim/stremthru/internal/torrent_info"
-	"github.com/MunifTanjim/stremthru/internal/torrent_stream"
+	"github.com/MunifTanjim/stremthru/internal/torz"
 	"github.com/MunifTanjim/stremthru/internal/util"
 	"github.com/MunifTanjim/stremthru/store"
-	"github.com/MunifTanjim/stremthru/store/torbox"
 )
 
 func getUser(ctx *storecontext.Context) (*store.User, error) {
@@ -406,32 +405,9 @@ func handleStoreLinkGenerate(w http.ResponseWriter, r *http.Request) {
 	ctx := storecontext.Get(r)
 	link, err := shared.GenerateStremThruLink(r, ctx, payload.Link, "")
 	if err == nil && link != nil {
-		go tryQueueMediaInfoProbe(ctx, payload.Link, link.Link)
+		go torz.TryQueueMediaInfoProbe(ctx, payload.Link, link.Link)
 	}
 	SendResponse(w, r, 200, link, err)
-}
-
-func tryQueueMediaInfoProbe(ctx *storecontext.Context, lockedLink, generatedLink string) {
-	if ctx.Store.GetName().Code() != store.StoreCodeTorBox {
-		return
-	}
-
-	id, fileId, err := torbox.LockedFileLink(lockedLink).Parse()
-	if err != nil {
-		return
-	}
-	params := &store.GetMagnetParams{Id: strconv.Itoa(id)}
-	params.APIKey = ctx.StoreAuthToken
-	magnet, err := ctx.Store.GetMagnet(params)
-	if err != nil {
-		return
-	}
-	for _, f := range magnet.Files {
-		if f.Link == lockedLink || f.Idx == fileId {
-			torrent_stream.QueueMediaInfoProbe(magnet.Hash, f.Path, generatedLink)
-			return
-		}
-	}
 }
 
 type contentProxyConnection struct {

--- a/internal/endpoint/store.go
+++ b/internal/endpoint/store.go
@@ -16,8 +16,10 @@ import (
 	store_util "github.com/MunifTanjim/stremthru/internal/store/util"
 	store_video "github.com/MunifTanjim/stremthru/internal/store/video"
 	"github.com/MunifTanjim/stremthru/internal/torrent_info"
+	"github.com/MunifTanjim/stremthru/internal/torrent_stream"
 	"github.com/MunifTanjim/stremthru/internal/util"
 	"github.com/MunifTanjim/stremthru/store"
+	"github.com/MunifTanjim/stremthru/store/torbox"
 )
 
 func getUser(ctx *storecontext.Context) (*store.User, error) {
@@ -403,7 +405,33 @@ func handleStoreLinkGenerate(w http.ResponseWriter, r *http.Request) {
 
 	ctx := storecontext.Get(r)
 	link, err := shared.GenerateStremThruLink(r, ctx, payload.Link, "")
+	if err == nil && link != nil {
+		go tryQueueMediaInfoProbe(ctx, payload.Link, link.Link)
+	}
 	SendResponse(w, r, 200, link, err)
+}
+
+func tryQueueMediaInfoProbe(ctx *storecontext.Context, lockedLink, generatedLink string) {
+	if ctx.Store.GetName().Code() != store.StoreCodeTorBox {
+		return
+	}
+
+	id, fileId, err := torbox.LockedFileLink(lockedLink).Parse()
+	if err != nil {
+		return
+	}
+	params := &store.GetMagnetParams{Id: strconv.Itoa(id)}
+	params.APIKey = ctx.StoreAuthToken
+	magnet, err := ctx.Store.GetMagnet(params)
+	if err != nil {
+		return
+	}
+	for _, f := range magnet.Files {
+		if f.Link == lockedLink || f.Idx == fileId {
+			torrent_stream.QueueMediaInfoProbe(magnet.Hash, f.Path, generatedLink)
+			return
+		}
+	}
 }
 
 type contentProxyConnection struct {

--- a/internal/torz/store.go
+++ b/internal/torz/store.go
@@ -14,8 +14,10 @@ import (
 	"github.com/MunifTanjim/stremthru/internal/shared"
 	storecontext "github.com/MunifTanjim/stremthru/internal/store/context"
 	store_util "github.com/MunifTanjim/stremthru/internal/store/util"
+	"github.com/MunifTanjim/stremthru/internal/torrent_stream"
 	"github.com/MunifTanjim/stremthru/internal/util"
 	"github.com/MunifTanjim/stremthru/store"
+	"github.com/MunifTanjim/stremthru/store/torbox"
 )
 
 func handleStoreTorzCheck(w http.ResponseWriter, r *http.Request) {
@@ -311,5 +313,30 @@ func handleStoreTorzLinkGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	go TryQueueMediaInfoProbe(ctx, payload.Link, data.Link)
+
 	server.SendData(w, r, 200, data)
+}
+
+func TryQueueMediaInfoProbe(ctx *storecontext.Context, lockedLink, generatedLink string) {
+	if ctx.Store.GetName().Code() != store.StoreCodeTorBox {
+		return
+	}
+
+	id, fileId, err := torbox.LockedFileLink(lockedLink).Parse()
+	if err != nil {
+		return
+	}
+	params := &store.GetMagnetParams{Id: strconv.Itoa(id)}
+	params.APIKey = ctx.StoreAuthToken
+	magnet, err := ctx.Store.GetMagnet(params)
+	if err != nil {
+		return
+	}
+	for _, f := range magnet.Files {
+		if f.Link == lockedLink || f.Idx == fileId {
+			torrent_stream.QueueMediaInfoProbe(magnet.Hash, f.Path, generatedLink)
+			return
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- `QueueMediaInfoProbe` is only called from the native playback handlers (torz/wrap), not the generic store API
- Resolves hash and path from the locked-link URI and queues the probe asynchronously after link generation
- No changes to the request payload

## Test plan
- [ ] Verify probe is queued when generating a TorBox link via `/v0/store/link/generate`
- [ ] Verify non-TorBox stores are unaffected
- [ ] Verify link generation response latency is unchanged (probe runs in background goroutine)