### PR TITLE
fix(stremio/store): add stremthru usenet prefix to getIdPrefixes

### DIFF
--- a/internal/stremio/store/userdata.go
+++ b/internal/stremio/store/userdata.go
@@ -55,6 +55,12 @@ func (ud *UserData) getIdPrefixes() []string {
 		if ud.StoreName == "" {
 			if user, err := util.ParseBasicAuth(ud.StoreToken); err == nil {
 				if password := config.Auth.GetPassword(user.Username); password != "" && password == user.Password {
+					if ud.EnableUsenet {
+						storeName := store.StoreNameStremThru
+						storeCode := string(storeName.Code())
+						code := storeCode + "-usenet"
+						ud.idPrefixes = append(ud.idPrefixes, getIdPrefix(code))
+					}
 					for _, name := range config.StoreAuthToken.ListStores(user.Username) {
 						storeName := store.StoreName(name)
 						storeCode := "st-" + string(storeName.Code())


### PR DESCRIPTION
getIdPrefixes() is missing the StremThru usenet prefix (st:store:st-usenet:), so the stream handler never searches the StremThru usenet store when resolving IMDb content — zero streams returned even when content exists in the catalog. Adds the missing prefix, matching the same logic already in GetManifest().

Fixes #538