### PR TITLE
feat(store): add Torrin store support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Check [documentation](https://docs.stremthru.13377001.xyz).
 - [Premiumize](https://www.premiumize.me/ref/634502061)
 - [RealDebrid](http://real-debrid.com/?id=12448969)
 - [TorBox](https://torbox.app/subscription?referral=fbe2c844-4b50-416a-9cd8-4e37925f5dfa)
+- [Torrin](https://torrin.app)
 
 ### SDK
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -152,6 +152,7 @@ If `username` is `*`, it is used as a fallback for users without explicit store 
 | Premiumize  | `premiumize` | `<api-key>`          |
 | RealDebrid  | `realdebrid` | `<api-token>`        |
 | TorBox      | `torbox`     | `<api-key>`          |
+| Torrin      | `torrin`     | `<api-key>`          |
 
 **Example:**
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -17,6 +17,7 @@ Supported stores:
 - [Premiumize](https://www.premiumize.me/ref/634502061)
 - [RealDebrid](http://real-debrid.com/?id=12448969)
 - [TorBox](https://torbox.app/subscription?referral=fbe2c844-4b50-416a-9cd8-4e37925f5dfa)
+- [Torrin](https://torrin.app)
 
 ## Stremio Addons
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ hero:
 
 features:
   - title: Store Integrations
-    details: Connect to 9 debrid services — AllDebrid, Debrider, Debrid-Link, EasyDebrid, Offcloud, PikPak, Premiumize, RealDebrid, and TorBox — through a unified API.
+    details: Connect to 10 debrid services — AllDebrid, Debrider, Debrid-Link, EasyDebrid, Offcloud, PikPak, Premiumize, RealDebrid, TorBox, and Torrin — through a unified API.
     link: /configuration/
   - title: Stremio Addons
     details: Five built-in addons — Store, Wrap, Torz, Newz and List — to enhance your Stremio experience. And a tool — Sidekick — for extra features missing in Stremio.

--- a/internal/shared/store.go
+++ b/internal/shared/store.go
@@ -24,6 +24,7 @@ import (
 	"github.com/MunifTanjim/stremthru/store/realdebrid"
 	"github.com/MunifTanjim/stremthru/store/stremthru"
 	"github.com/MunifTanjim/stremthru/store/torbox"
+	"github.com/MunifTanjim/stremthru/store/torrin"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -64,6 +65,10 @@ var tbStore = torbox.NewStoreClient(&torbox.StoreClientConfig{
 	HTTPClient: config.GetHTTPClient(config.StoreTunnel.GetTypeForAPI("torbox")),
 	UserAgent:  config.StoreClientUserAgent,
 })
+var toStore = torrin.NewStoreClient(&torrin.StoreClientConfig{
+	HTTPClient: config.GetHTTPClient(config.StoreTunnel.GetTypeForAPI("torrin")),
+	UserAgent:  config.StoreClientUserAgent,
+})
 
 func GetStore(name string) store.Store {
 	switch store.StoreName(name) {
@@ -87,6 +92,8 @@ func GetStore(name string) store.Store {
 		return stStore
 	case store.StoreNameTorBox:
 		return tbStore
+	case store.StoreNameTorrin:
+		return toStore
 	default:
 		return nil
 	}
@@ -114,6 +121,8 @@ func GetStoreByCode(code string) store.Store {
 		return stStore
 	case store.StoreCodeTorBox:
 		return tbStore
+	case store.StoreCodeTorrin:
+		return toStore
 	default:
 		return nil
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -23,6 +23,7 @@ const (
 	StoreNameRealDebrid StoreName = "realdebrid"
 	StoreNameStremThru  StoreName = "stremthru"
 	StoreNameTorBox     StoreName = "torbox"
+	StoreNameTorrin     StoreName = "torrin"
 )
 
 func (n StoreName) String() string {
@@ -39,6 +40,7 @@ var StoreNames = []StoreName{
 	StoreNamePremiumize,
 	StoreNameRealDebrid,
 	StoreNameTorBox,
+	StoreNameTorrin,
 }
 
 type StoreCode string
@@ -54,6 +56,7 @@ const (
 	StoreCodeRealDebrid StoreCode = "rd"
 	StoreCodeStremThru  StoreCode = "st"
 	StoreCodeTorBox     StoreCode = "tb"
+	StoreCodeTorrin     StoreCode = "tr"
 )
 
 var storeCodeByName = map[StoreName]StoreCode{
@@ -67,6 +70,7 @@ var storeCodeByName = map[StoreName]StoreCode{
 	StoreNameRealDebrid: StoreCodeRealDebrid,
 	StoreNameStremThru:  StoreCodeStremThru,
 	StoreNameTorBox:     StoreCodeTorBox,
+	StoreNameTorrin:     StoreCodeTorrin,
 }
 
 var storeNameByCode = map[StoreCode]StoreName{
@@ -80,6 +84,7 @@ var storeNameByCode = map[StoreCode]StoreName{
 	StoreCodeRealDebrid: StoreNameRealDebrid,
 	StoreCodeStremThru:  StoreNameStremThru,
 	StoreCodeTorBox:     StoreNameTorBox,
+	StoreCodeTorrin:     StoreNameTorrin,
 }
 
 func (sn StoreName) Code() StoreCode {

--- a/store/torrin/store.go
+++ b/store/torrin/store.go
@@ -1,0 +1,181 @@
+package torrin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/MunifTanjim/stremthru/core"
+	"github.com/MunifTanjim/stremthru/internal/config"
+	"github.com/MunifTanjim/stremthru/store"
+)
+
+// Torrin implements the StremThru store API directly, so this client is a thin
+// forwarder: each store method maps 1:1 to a /v0/store/* endpoint and decodes
+// the standard {"data": ...} envelope into the shared store types.
+
+const defaultBaseURL = "https://api.torrin.app"
+
+var DefaultHTTPClient = config.DefaultHTTPClient
+
+type StoreClientConfig struct {
+	BaseURL    string // default: https://api.torrin.app
+	HTTPClient *http.Client
+	UserAgent  string
+}
+
+type StoreClient struct {
+	Name       store.StoreName
+	baseURL    string
+	httpClient *http.Client
+	agent      string
+}
+
+var _ store.Store = (*StoreClient)(nil)
+
+func NewStoreClient(conf *StoreClientConfig) *StoreClient {
+	if conf == nil {
+		conf = &StoreClientConfig{}
+	}
+	c := &StoreClient{Name: store.StoreNameTorrin}
+
+	c.baseURL = strings.TrimRight(conf.BaseURL, "/")
+	if c.baseURL == "" {
+		c.baseURL = defaultBaseURL
+	}
+
+	c.httpClient = conf.HTTPClient
+	if c.httpClient == nil {
+		c.httpClient = DefaultHTTPClient
+	}
+
+	c.agent = conf.UserAgent
+	if c.agent == "" {
+		c.agent = "stremthru"
+	}
+
+	return c
+}
+
+func (c *StoreClient) GetName() store.StoreName {
+	return c.Name
+}
+
+func (c *StoreClient) newError(msg string, statusCode int) error {
+	err := core.NewStoreError(msg)
+	err.StoreName = string(store.StoreNameTorrin)
+	err.StatusCode = statusCode
+	return err
+}
+
+// doRequest performs an authenticated call and decodes the {"data": T} envelope.
+func doRequest[T any](c *StoreClient, ctx context.Context, method, path, apiKey string, query url.Values, body any) (*T, error) {
+	reqURL := c.baseURL + path
+	if len(query) > 0 {
+		reqURL += "?" + query.Encode()
+	}
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, c.newError("failed to encode request", http.StatusInternalServerError)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, reader)
+	if err != nil {
+		return nil, c.newError("failed to create request", http.StatusInternalServerError)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("User-Agent", c.agent)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, c.newError("request failed: "+err.Error(), http.StatusBadGateway)
+	}
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, c.newError("failed to read response", http.StatusBadGateway)
+	}
+
+	if res.StatusCode >= 400 {
+		var envErr struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		_ = json.Unmarshal(data, &envErr)
+		msg := envErr.Error.Message
+		if msg == "" {
+			msg = "upstream error"
+		}
+		return nil, c.newError(msg, res.StatusCode)
+	}
+
+	var env struct {
+		Data T `json:"data"`
+	}
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, c.newError("failed to decode response", http.StatusBadGateway)
+	}
+	return &env.Data, nil
+}
+
+func (c *StoreClient) GetUser(params *store.GetUserParams) (*store.User, error) {
+	return doRequest[store.User](c, params.GetContext(), http.MethodGet, "/v0/store/user", params.GetAPIKey(""), nil, nil)
+}
+
+func (c *StoreClient) CheckMagnet(params *store.CheckMagnetParams) (*store.CheckMagnetData, error) {
+	query := url.Values{}
+	for _, m := range params.Magnets {
+		query.Add("magnet", m)
+	}
+	if params.SId != "" {
+		query.Set("sid", params.SId)
+	}
+	if params.ClientIP != "" {
+		query.Set("client_ip", params.ClientIP)
+	}
+	return doRequest[store.CheckMagnetData](c, params.GetContext(), http.MethodGet, "/v0/store/magnets/check", params.GetAPIKey(""), query, nil)
+}
+
+func (c *StoreClient) AddMagnet(params *store.AddMagnetParams) (*store.AddMagnetData, error) {
+	body := map[string]string{"magnet": params.Magnet}
+	return doRequest[store.AddMagnetData](c, params.GetContext(), http.MethodPost, "/v0/store/magnets", params.GetAPIKey(""), nil, body)
+}
+
+func (c *StoreClient) GetMagnet(params *store.GetMagnetParams) (*store.GetMagnetData, error) {
+	return doRequest[store.GetMagnetData](c, params.GetContext(), http.MethodGet, "/v0/store/magnets/"+url.PathEscape(params.Id), params.GetAPIKey(""), nil, nil)
+}
+
+func (c *StoreClient) ListMagnets(params *store.ListMagnetsParams) (*store.ListMagnetsData, error) {
+	query := url.Values{}
+	if params.Limit > 0 {
+		query.Set("limit", strconv.Itoa(params.Limit))
+	}
+	if params.Offset > 0 {
+		query.Set("offset", strconv.Itoa(params.Offset))
+	}
+	return doRequest[store.ListMagnetsData](c, params.GetContext(), http.MethodGet, "/v0/store/magnets", params.GetAPIKey(""), query, nil)
+}
+
+func (c *StoreClient) RemoveMagnet(params *store.RemoveMagnetParams) (*store.RemoveMagnetData, error) {
+	return doRequest[store.RemoveMagnetData](c, params.GetContext(), http.MethodDelete, "/v0/store/magnets/"+url.PathEscape(params.Id), params.GetAPIKey(""), nil, nil)
+}
+
+func (c *StoreClient) GenerateLink(params *store.GenerateLinkParams) (*store.GenerateLinkData, error) {
+	body := map[string]string{"link": params.Link}
+	return doRequest[store.GenerateLinkData](c, params.GetContext(), http.MethodPost, "/v0/store/link/generate", params.GetAPIKey(""), nil, body)
+}


### PR DESCRIPTION
Adds [Torrin](https://torrin.app) as a supported store.

Torrin is an open-source debrid service that implements the StremThru store API, so the client is a thin forwarder: each `Store` method maps 1:1 to the matching `/v0/store/*` endpoint and decodes the standard `{"data": ...}` envelope into the shared `store` types. No API translation needed.

- New `store/torrin` package implementing the `Store` interface
- Registered name `torrin` / code `tr` in `store/store.go` and the `shared` factory
- Base URL defaults to `https://api.torrin.app`, overridable via config
- Docs + README updated

Happy to adjust naming/scope or make the base URL env-configurable if you'd prefer.