### PR TITLE
feat(store/torbox): add opt-in permalink link generation

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -192,6 +192,29 @@ If `store_name` is `*`, it is used as a fallback.
 STREMTHRU_STORE_CONTENT_PROXY=*:true
 ```
 
+### `STREMTHRU_STORE_TORBOX_PERMALINK`
+
+Return permanent TorBox links instead of temporary ones.
+
+When enabled, the TorBox store returns the permanent `requestdl?...&redirect=true` link form, which redirects to a fresh CDN link on every access and never expires. This avoids having to re-generate a link when a temporary one expires mid-stream.
+
+| `value` | Description                      |
+| ------- | -------------------------------- |
+| `true`  | Return permanent links           |
+| `false` | Return temporary links (default) |
+
+- **Default:** `false`
+
+**Example:**
+
+```sh
+STREMTHRU_STORE_TORBOX_PERMALINK=true
+```
+
+::: warning
+The permanent link embeds your TorBox API token. Only enable it when every consumer of the generated link is trusted (e.g. a self-hosted setup with content proxy enabled, or an entirely local setup). With content proxy disabled or pass-through access, the token would be exposed to the streaming client.
+:::
+
 ### `STREMTHRU_CONTENT_PROXY_CONNECTION_LIMIT`
 
 Comma-separated list of content proxy connection limits per user in `username:connection_limit` format.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ var defaultValueByEnv = map[string]map[string]string{
 		"STREMTHRU_STORE_CONTENT_PROXY":                    "*:true",
 		"STREMTHRU_STORE_TUNNEL":                           "*:true",
 		"STREMTHRU_STORE_CLIENT_USER_AGENT":                "stremthru",
+		"STREMTHRU_STORE_TORBOX_PERMALINK":                 "false",
 		"STREMTHRU_INTEGRATION_ANILIST_LIST_STALE_TIME":    "12h",
 		"STREMTHRU_INTEGRATION_LETTERBOXD_LIST_STALE_TIME": "24h",
 		"STREMTHRU_INTEGRATION_LETTERBOXD_USER_AGENT":      "stremthru",
@@ -350,6 +351,7 @@ type Config struct {
 	StoreContentProxy           StoreContentProxyMap
 	StoreContentCachedStaleTime storeContentCachedStaleTimeMap
 	StoreClientUserAgent        string
+	StoreTorBoxPermalink        bool
 	ContentProxyConnectionLimit ContentProxyConnectionLimitMap
 
 	DataDir     string
@@ -590,6 +592,7 @@ var config = func() Config {
 		StoreContentProxy:           storeContentProxyMap,
 		StoreContentCachedStaleTime: storeContentCachedStaleTimeMap,
 		StoreClientUserAgent:        getEnv("STREMTHRU_STORE_CLIENT_USER_AGENT"),
+		StoreTorBoxPermalink:        getEnv("STREMTHRU_STORE_TORBOX_PERMALINK") == "true",
 		ContentProxyConnectionLimit: contentProxyConnectionMap,
 		DataDir:                     dataDir,
 		VaultSecret:                 vaultSecret,
@@ -618,6 +621,7 @@ var ServerStartTime = config.ServerStartTime
 var StoreContentProxy = config.StoreContentProxy
 var StoreContentCachedStaleTime = config.StoreContentCachedStaleTime
 var StoreClientUserAgent = config.StoreClientUserAgent
+var StoreTorBoxPermalink = config.StoreTorBoxPermalink
 var ContentProxyConnectionLimit = config.ContentProxyConnectionLimit
 var InstanceId = strings.ReplaceAll(uuid.NewString(), "-", "")
 

--- a/store/torbox/store.go
+++ b/store/torbox/store.go
@@ -2,6 +2,7 @@ package torbox
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/MunifTanjim/stremthru/core"
 	"github.com/MunifTanjim/stremthru/internal/buddy"
 	"github.com/MunifTanjim/stremthru/internal/cache"
+	"github.com/MunifTanjim/stremthru/internal/config"
 	"github.com/MunifTanjim/stremthru/internal/torrent_stream"
 	"github.com/MunifTanjim/stremthru/internal/util"
 	"github.com/MunifTanjim/stremthru/store"
@@ -366,6 +368,22 @@ func (c *StoreClient) GenerateLink(params *store.GenerateLinkParams) (*store.Gen
 		error.Cause = err
 		return nil, error
 	}
+
+	// Opt-in: return TorBox's permalink (a stable URL that 307-redirects to a
+	// fresh CDN link on every access) instead of a temporary one that expires in
+	// a few hours. It embeds the API token in the URL, so it is gated behind
+	// STREMTHRU_STORE_TORBOX_PERMALINK and should only be used with trusted consumers.
+	if config.StoreTorBoxPermalink {
+		query := url.Values{}
+		query.Add("token", params.GetAPIKey(c.client.apiKey))
+		query.Add("torrent_id", strconv.Itoa(torrentId))
+		query.Add("file_id", strconv.Itoa(fileId))
+		query.Add("redirect", "true")
+		link := c.client.BaseURL.JoinPath("/v1/api/torrents/requestdl")
+		link.RawQuery = query.Encode()
+		return &store.GenerateLinkData{Link: link.String()}, nil
+	}
+
 	if v := c.getCachedGeneratedLink(params, torrentId, fileId); v != nil {
 		return v, nil
 	}


### PR DESCRIPTION
TorBox's `requestdl` endpoint supports a `redirect=true` parameter that returns a **permanent** link: a stable URL that `307`-redirects to a fresh CDN link on every access, instead of the temporary link (expires after a few hours) it returns today.

This adds an opt-in `STREMTHRU_STORE_TORBOX_PERMALINK` option (default `false`) that makes the TorBox store's `GenerateLink` return that permalink form. When it's off, behavior is unchanged.

### Why

With the temporary link, a consumer that holds onto the link has to re-generate it before it expires, and if it expires mid-stream the read fails. When a media manager backs a FUSE mount with these links, a long-lived link going stale can wedge the mount. The permalink is stable, so the consumer keeps one URL and TorBox hands back a fresh CDN link on each access.

### Why opt-in / default off

The permalink form embeds the TorBox API token in the URL (`?token=...`). That's fine when the link stays server-side or every consumer is trusted (self-hosted with content proxy enabled, or a fully local setup), but it would expose the token if the link is handed straight to an untrusted client. So it's gated behind the option and documented with that caveat.

The `redirect` field was already stubbed (commented out) in `RequestDownloadLink`; this implements it as plain URL construction in `GenerateLink`, so there's no extra TorBox round-trip.

### Testing

- With the option on, `GenerateLink` returns `…/v1/api/torrents/requestdl?...&redirect=true`. That URL `307`s to a CDN link that serves `Range` requests (`206 Partial Content`), and a `HEAD` with `Range: bytes=0-0` returns `200`.
- With the option off, the existing temporary-link path is unchanged.
- `go build ./...` and `go vet ./...` pass.
