### PR TITLE
feat(torz): try to record torrent info when generating links

### DIFF
--- a/internal/torz/store.go
+++ b/internal/torz/store.go
@@ -369,6 +369,7 @@ func TryQueueMediaInfoProbe(ctx *storecontext.Context, lockedLink string, linkDa
 		if err != nil {
 			return
 		}
+		go buddy.TrackMagnet(ctx.Store, magnet.Hash, magnet.Name, magnet.Size, magnet.Private, magnet.Files, "", magnet.Status != store.MagnetStatusDownloaded, ctx.StoreAuthToken)
 		for _, f := range magnet.Files {
 			if f.Link == lockedLink || f.Idx == fileId {
 				torrent_stream.QueueMediaInfoProbe(magnet.Hash, f.Path, linkData.Link)


### PR DESCRIPTION
Reuse the magnet data already fetched for the media info probe to also track it, so hash/title/size/files/private get ingested for TorBox links generated via the store API and store addon playback.

**Why:** ingestion already happens on add/get/check-magnet and addon playback, but not on link-generate. This closes that gap — mainly catching out-of-band torrents (added on the TorBox site or a prior session) that reach playback via the store catalog/API without a prior tracked add. TorBox-only; idempotent when the hash was already tracked; safe (empty category never downgrades an existing row).

---

this is created with Claude since I don't have either go or project internal knowledge. what I want to achieve is basically more aggressive private torrent/hash ingestion, for people like me using private trackers, to help the whole (TB) community get high quality cached private hashes faster. it seems like ingestion does not happen on link creation yet. but I obviously don't know if this is the best solution for that. thought about trying to create this small PR instead of annoying you with a discussion :)
