### PR TITLE
fix(stremio): surface torrin in addons

### DIFF
--- a/internal/stremio/configure/configure_script.go
+++ b/internal/stremio/configure/configure_script.go
@@ -24,6 +24,7 @@ function onStoreNameChangeUpdateStoreTokenDescription(nameField) {
     premiumize: "pm",
     realdebrid: "rd",
     torbox: "tb",
+    torrin: "ti",
     p2p: "p2p",
   };
   const nameDescElem = document.querySelector(` + "`[name='${nameField.name}'] + small > span.description`" + `);
@@ -40,6 +41,7 @@ function onStoreNameChangeUpdateStoreTokenDescription(nameField) {
       pp: "<a type='button' class='outline mb-0' style='font-size: 0.75rem; padding: 0.02em 0.5em;' target='_blank' href='https://mypikpak.com/drive/activity/invited?invitation-code=46013321'>Sign Up</a> Invitation Code: <a target='_blank' href='https://mypikpak.com/drive/activity/invited?invitation-code=46013321'><code>46013321</code></a>",
       rd: "<a type='button' class='outline mb-0' style='font-size: 0.75rem; padding: 0.02em 0.5em;' target='_blank' href='http://real-debrid.com/?id=12448969'>Sign Up<a>",
       tb: "<a type='button' class='outline mb-0' style='font-size: 0.75rem; padding: 0.02em 0.5em;' target='_blank' href='https://torbox.app/subscription?referral=fbe2c844-4b50-416a-9cd8-4e37925f5dfa'>Sign Up</a> Referral Code: <a target='_blank' href='https://torbox.app/subscription?referral=fbe2c844-4b50-416a-9cd8-4e37925f5dfa'><code>fbe2c844-4b50-416a-9cd8-4e37925f5dfa</code></a>",
+      ti: "<a type='button' class='outline mb-0' style='font-size: 0.75rem; padding: 0.02em 0.5em;' target='_blank' href='https://torrin.app/login'>Sign Up</a>",
       p2p: "⚠️ Peer-to-Peer (🧪 Experimental)",
     };
     nameDescElem.innerHTML = descByStore[nameField.value] || descByStore[storeFallback[nameField.value]] || descByStore["*"] || "";
@@ -59,6 +61,7 @@ function onStoreNameChangeUpdateStoreTokenDescription(nameField) {
 			pp: "PikPak <a href='https://mypikpak.com/drive/account/basic' target='_blank'>credential</a> in <code>email:password</code> format, e.g. <code>john.doe@example.com:secret-password</code>",
 			rd: "RealDebrid <a href='https://real-debrid.com/apitoken' target='_blank'>API Token</a>",
 			tb: "TorBox <a href='https://torbox.app/settings' target='_blank'>API Key</a>",
+			ti: "Torrin <a href='https://torrin.app/app/settings' target='_blank'>API Key</a>",
 			p2p: "…",
 		};
     tokenDescElem.innerHTML = descByStore[nameField.value] || descByStore[storeFallback[nameField.value]] || descByStore["*"] || "";

--- a/internal/stremio/shared/store.go
+++ b/internal/stremio/shared/store.go
@@ -23,6 +23,7 @@ func GetStoreCodeOptions(includeP2P bool) []configure.ConfigOption {
 		{Value: "pp", Label: "PikPak"},
 		{Value: "rd", Label: "RealDebrid"},
 		{Value: "tb", Label: "TorBox"},
+		{Value: "ti", Label: "🧪 Torrin"},
 	}
 	if config.IsPublicInstance {
 		options[0].Disabled = true

--- a/internal/stremio/store/manifest.go
+++ b/internal/stremio/store/manifest.go
@@ -33,6 +33,7 @@ var logoByStoreCode = map[string]string{
 	"pp": "https://mypikpak.com/android-chrome-192x192.png",
 	"rd": "https://fcdn.real-debrid.com/0830/favicons/android-chrome-192x192.png",
 	"tb": "https://torbox.app/android-chrome-192x192.png",
+	"ti": "https://torrin.app/favicon.png",
 }
 
 func getManifestCatalog(code string, hideCatalog bool) stremio.Catalog {

--- a/internal/stremio/store/template.go
+++ b/internal/stremio/store/template.go
@@ -50,6 +50,7 @@ func getStoreNameConfig(defaultValue string) configure.Config {
 		{Value: "premiumize", Label: "Premiumize"},
 		{Value: "realdebrid", Label: "RealDebrid"},
 		{Value: "torbox", Label: "TorBox"},
+		{Value: "torrin", Label: "🧪 Torrin"},
 	}
 	if config.IsPublicInstance {
 		options[0].Disabled = true


### PR DESCRIPTION
Wires Torrin into the addon layer (the `ti` store client already exists):

- store + wrap/torz store selectors
- configure API-key hint
- catalog logo
- torrent-info from `ListMagnets`