### PR TITLE
feat(store): configurable Torrin base URL for self-hosted instances

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -355,6 +355,7 @@ type Config struct {
 	StoreContentProxy           StoreContentProxyMap
 	StoreContentCachedStaleTime storeContentCachedStaleTimeMap
 	StoreClientUserAgent        string
+	StoreTorrinBaseURL          string
 	ContentProxyConnectionLimit ContentProxyConnectionLimitMap
 
 	DataDir     string
@@ -374,6 +375,24 @@ func parseUri(uri string) (parsedUrl, parsedToken string) {
 	u.User = nil
 	parsedUrl = strings.TrimSpace(u.String())
 	return
+}
+
+func parseStoreBaseURL(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	u, err := url.Parse(value)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("scheme must be http or https")
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("host is required")
+	}
+	return strings.TrimRight(value, "/"), nil
 }
 
 var config = func() Config {
@@ -471,6 +490,11 @@ var config = func() Config {
 	peerUrl, peerAuthToken := "", ""
 	if peerUri != "-" {
 		peerUrl, peerAuthToken = parseUri(peerUri)
+	}
+
+	torrinBaseURL, tiErr := parseStoreBaseURL(getEnv("STREMTHRU_STORE_TORRIN_BASE_URL"))
+	if tiErr != nil {
+		log.Fatalf("invalid STREMTHRU_STORE_TORRIN_BASE_URL: %v", tiErr)
 	}
 
 	databaseUri := getEnv("STREMTHRU_DATABASE_URI")
@@ -595,6 +619,7 @@ var config = func() Config {
 		StoreContentProxy:           storeContentProxyMap,
 		StoreContentCachedStaleTime: storeContentCachedStaleTimeMap,
 		StoreClientUserAgent:        getEnv("STREMTHRU_STORE_CLIENT_USER_AGENT"),
+		StoreTorrinBaseURL:          torrinBaseURL,
 		ContentProxyConnectionLimit: contentProxyConnectionMap,
 		DataDir:                     dataDir,
 		VaultSecret:                 vaultSecret,
@@ -623,6 +648,7 @@ var ServerStartTime = config.ServerStartTime
 var StoreContentProxy = config.StoreContentProxy
 var StoreContentCachedStaleTime = config.StoreContentCachedStaleTime
 var StoreClientUserAgent = config.StoreClientUserAgent
+var StoreTorrinBaseURL = config.StoreTorrinBaseURL
 var ContentProxyConnectionLimit = config.ContentProxyConnectionLimit
 var InstanceId = strings.ReplaceAll(uuid.NewString(), "-", "")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,3 +59,21 @@ func (s *StoreContentCachedStaleTimeTestSuite) TestStoreContentCachedStaleTimeWi
 func TestConfig(t *testing.T) {
 	suite.Run(t, new(StoreContentCachedStaleTimeTestSuite))
 }
+
+func TestParseStoreBaseURL(t *testing.T) {
+	if got, err := parseStoreBaseURL(""); err != nil || got != "" {
+		t.Errorf("empty: got %q, err %v", got, err)
+	}
+	if got, err := parseStoreBaseURL("https://torrin.example.com/"); err != nil || got != "https://torrin.example.com" {
+		t.Errorf("https: got %q, err %v", got, err)
+	}
+	if got, err := parseStoreBaseURL("http://10.0.0.5:8080"); err != nil || got != "http://10.0.0.5:8080" {
+		t.Errorf("http+port: got %q, err %v", got, err)
+	}
+	if _, err := parseStoreBaseURL("ftp://x"); err == nil {
+		t.Error("ftp scheme should error")
+	}
+	if _, err := parseStoreBaseURL("torrin.example.com"); err == nil {
+		t.Error("scheme-less should error")
+	}
+}

--- a/internal/shared/store.go
+++ b/internal/shared/store.go
@@ -66,6 +66,7 @@ var tbStore = torbox.NewStoreClient(&torbox.StoreClientConfig{
 	UserAgent:  config.StoreClientUserAgent,
 })
 var tiStore = torrin.NewStoreClient(&torrin.StoreClientConfig{
+	BaseURL:    config.StoreTorrinBaseURL,
 	HTTPClient: config.GetHTTPClient(config.StoreTunnel.GetTypeForAPI("torrin")),
 	UserAgent:  config.StoreClientUserAgent,
 })


### PR DESCRIPTION
Torrin is the one store that can be self-hosted, but its base URL is hardcoded to `https://api.torrin.app`, so a self-hosted Torrin instance can't be reached through StremThru.

This adds an operator env var `STREMTHRU_STORE_TORRIN_BASE_URL` to point the Torrin store at a self-hosted instance.

- Defaults to `https://api.torrin.app` when unset, so existing deployments are unaffected.
- Validated: must be an `http`/`https` URL with a host.
- **Operator-set env only** (read once at startup, never from a request/token/per-user config), so it is not an SSRF vector.
- Only the Torrin store is affected; every other store keeps its fixed endpoint.
- Unit test for the URL validation included.