### PR TITLE
feat(store): add Webtor store support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Check [documentation](https://docs.stremthru.13377001.xyz).
 - [RealDebrid](http://real-debrid.com/?id=12448969)
 - [TorBox](https://torbox.app/subscription?referral=fbe2c844-4b50-416a-9cd8-4e37925f5dfa)
 - [Torrin](https://torrin.app)
+- [Webtor](https://webtor.io)
 
 ### SDK
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -153,6 +153,7 @@ If `username` is `*`, it is used as a fallback for users without explicit store 
 | RealDebrid  | `realdebrid` | `<api-token>`        |
 | TorBox      | `torbox`     | `<api-key>`          |
 | Torrin      | `torrin`     | `<api-key>`          |
+| Webtor      | `webtor`     | `<api-key>`          |
 
 **Example:**
 

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -18,6 +18,7 @@ Supported stores:
 - [RealDebrid](http://real-debrid.com/?id=12448969)
 - [TorBox](https://torbox.app/subscription?referral=fbe2c844-4b50-416a-9cd8-4e37925f5dfa)
 - [Torrin](https://torrin.app)
+- [Webtor](https://webtor.io)
 
 ## Stremio Addons
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ hero:
 
 features:
   - title: Store Integrations
-    details: Connect to 10 debrid services — AllDebrid, Debrider, Debrid-Link, EasyDebrid, Offcloud, PikPak, Premiumize, RealDebrid, TorBox, and Torrin — through a unified API.
+    details: Connect to 11 debrid services — AllDebrid, Debrider, Debrid-Link, EasyDebrid, Offcloud, PikPak, Premiumize, RealDebrid, TorBox, Torrin, and Webtor — through a unified API.
     link: /configuration/
   - title: Stremio Addons
     details: Five built-in addons — Store, Wrap, Torz, Newz and List — to enhance your Stremio experience. And a tool — Sidekick — for extra features missing in Stremio.

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/vmihailenco/go-tinylfu v0.2.2 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/webtor-io/api-sdk-go v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go4.org v0.0.0-20200411211856-f5505b9728dd // indirect
 	golang.org/x/crypto v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/webtor-io/api-sdk-go v0.4.0 h1:TWyCIBA7rwEFPx3hin7eozvD1/UdXKVd8v6KWwPor6U=
+github.com/webtor-io/api-sdk-go v0.4.0/go.mod h1:XElu75VwGKEE+dBy0MSCd+2qQL/15oz+yoEruDx0j30=
 github.com/willf/bitset v1.1.9/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=

--- a/internal/shared/store.go
+++ b/internal/shared/store.go
@@ -25,6 +25,7 @@ import (
 	"github.com/MunifTanjim/stremthru/store/stremthru"
 	"github.com/MunifTanjim/stremthru/store/torbox"
 	"github.com/MunifTanjim/stremthru/store/torrin"
+	"github.com/MunifTanjim/stremthru/store/webtor"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -69,6 +70,10 @@ var tiStore = torrin.NewStoreClient(&torrin.StoreClientConfig{
 	HTTPClient: config.GetHTTPClient(config.StoreTunnel.GetTypeForAPI("torrin")),
 	UserAgent:  config.StoreClientUserAgent,
 })
+var wtStore = webtor.NewStoreClient(&webtor.StoreClientConfig{
+	HTTPClient: config.GetHTTPClient(config.StoreTunnel.GetTypeForAPI("webtor")),
+	UserAgent:  config.StoreClientUserAgent,
+})
 
 func GetStore(name string) store.Store {
 	switch store.StoreName(name) {
@@ -94,6 +99,8 @@ func GetStore(name string) store.Store {
 		return tbStore
 	case store.StoreNameTorrin:
 		return tiStore
+	case store.StoreNameWebtor:
+		return wtStore
 	default:
 		return nil
 	}
@@ -123,6 +130,8 @@ func GetStoreByCode(code string) store.Store {
 		return tbStore
 	case store.StoreCodeTorrin:
 		return tiStore
+	case store.StoreCodeWebtor:
+		return wtStore
 	default:
 		return nil
 	}

--- a/internal/stremio/configure/configure_script.go
+++ b/internal/stremio/configure/configure_script.go
@@ -25,6 +25,7 @@ function onStoreNameChangeUpdateStoreTokenDescription(nameField) {
     realdebrid: "rd",
     torbox: "tb",
     torrin: "ti",
+    webtor: "wt",
     p2p: "p2p",
   };
   const nameDescElem = document.querySelector(` + "`[name='${nameField.name}'] + small > span.description`" + `);
@@ -42,6 +43,7 @@ function onStoreNameChangeUpdateStoreTokenDescription(nameField) {
       rd: "<a type='button' class='outline mb-0' style='font-size: 0.75rem; padding: 0.02em 0.5em;' target='_blank' href='http://real-debrid.com/?id=12448969'>Sign Up<a>",
       tb: "<a type='button' class='outline mb-0' style='font-size: 0.75rem; padding: 0.02em 0.5em;' target='_blank' href='https://torbox.app/subscription?referral=fbe2c844-4b50-416a-9cd8-4e37925f5dfa'>Sign Up</a> Referral Code: <a target='_blank' href='https://torbox.app/subscription?referral=fbe2c844-4b50-416a-9cd8-4e37925f5dfa'><code>fbe2c844-4b50-416a-9cd8-4e37925f5dfa</code></a>",
       ti: "<a type='button' class='outline mb-0' style='font-size: 0.75rem; padding: 0.02em 0.5em;' target='_blank' href='https://torrin.app/login'>Sign Up</a>",
+      wt: "<a type='button' class='outline mb-0' style='font-size: 0.75rem; padding: 0.02em 0.5em;' target='_blank' href='https://webtor.io/login'>Sign Up</a>",
       p2p: "⚠️ Peer-to-Peer (🧪 Experimental)",
     };
     nameDescElem.innerHTML = descByStore[nameField.value] || descByStore[storeFallback[nameField.value]] || descByStore["*"] || "";
@@ -62,6 +64,7 @@ function onStoreNameChangeUpdateStoreTokenDescription(nameField) {
 			rd: "RealDebrid <a href='https://real-debrid.com/apitoken' target='_blank'>API Token</a>",
 			tb: "TorBox <a href='https://torbox.app/settings' target='_blank'>API Key</a>",
 			ti: "Torrin <a href='https://torrin.app/app/settings' target='_blank'>API Key</a>",
+			wt: "Webtor <a href='https://webtor.io/profile' target='_blank'>API Key</a>",
 			p2p: "…",
 		};
     tokenDescElem.innerHTML = descByStore[nameField.value] || descByStore[storeFallback[nameField.value]] || descByStore["*"] || "";

--- a/internal/stremio/shared/store.go
+++ b/internal/stremio/shared/store.go
@@ -24,6 +24,7 @@ func GetStoreCodeOptions(includeP2P bool) []configure.ConfigOption {
 		{Value: "rd", Label: "RealDebrid"},
 		{Value: "tb", Label: "TorBox"},
 		{Value: "ti", Label: "🧪 Torrin"},
+		{Value: "wt", Label: "Webtor"},
 	}
 	if config.IsPublicInstance {
 		options[0].Disabled = true

--- a/internal/stremio/store/manifest.go
+++ b/internal/stremio/store/manifest.go
@@ -34,6 +34,7 @@ var logoByStoreCode = map[string]string{
 	"rd": "https://fcdn.real-debrid.com/0830/favicons/android-chrome-192x192.png",
 	"tb": "https://torbox.app/android-chrome-192x192.png",
 	"ti": "https://torrin.app/favicon.png",
+	"wt": "https://webtor.io/android-chrome-192x192.png",
 }
 
 func getManifestCatalog(code string, hideCatalog bool) stremio.Catalog {

--- a/internal/stremio/store/template.go
+++ b/internal/stremio/store/template.go
@@ -51,6 +51,7 @@ func getStoreNameConfig(defaultValue string) configure.Config {
 		{Value: "realdebrid", Label: "RealDebrid"},
 		{Value: "torbox", Label: "TorBox"},
 		{Value: "torrin", Label: "🧪 Torrin"},
+		{Value: "webtor", Label: "Webtor"},
 	}
 	if config.IsPublicInstance {
 		options[0].Disabled = true

--- a/internal/torrent_info/db.go
+++ b/internal/torrent_info/db.go
@@ -103,6 +103,7 @@ const (
 	TorrentInfoSourceRealDebrid  TorrentInfoSource = "rd"
 	TorrentInfoSourceTorBox      TorrentInfoSource = "tb"
 	TorrentInfoSourceTorrin      TorrentInfoSource = "ti"
+	TorrentInfoSourceWebtor      TorrentInfoSource = "wt"
 	TorrentInfoSourceUnknown     TorrentInfoSource = ""
 )
 

--- a/store/store.go
+++ b/store/store.go
@@ -24,6 +24,7 @@ const (
 	StoreNameStremThru  StoreName = "stremthru"
 	StoreNameTorBox     StoreName = "torbox"
 	StoreNameTorrin     StoreName = "torrin"
+	StoreNameWebtor     StoreName = "webtor"
 )
 
 func (n StoreName) String() string {
@@ -41,6 +42,7 @@ var StoreNames = []StoreName{
 	StoreNameRealDebrid,
 	StoreNameTorBox,
 	StoreNameTorrin,
+	StoreNameWebtor,
 }
 
 type StoreCode string
@@ -57,6 +59,7 @@ const (
 	StoreCodeStremThru  StoreCode = "st"
 	StoreCodeTorBox     StoreCode = "tb"
 	StoreCodeTorrin     StoreCode = "ti"
+	StoreCodeWebtor     StoreCode = "wt"
 )
 
 var storeCodeByName = map[StoreName]StoreCode{
@@ -71,6 +74,7 @@ var storeCodeByName = map[StoreName]StoreCode{
 	StoreNameStremThru:  StoreCodeStremThru,
 	StoreNameTorBox:     StoreCodeTorBox,
 	StoreNameTorrin:     StoreCodeTorrin,
+	StoreNameWebtor:     StoreCodeWebtor,
 }
 
 var storeNameByCode = map[StoreCode]StoreName{
@@ -85,6 +89,7 @@ var storeNameByCode = map[StoreCode]StoreName{
 	StoreCodeStremThru:  StoreNameStremThru,
 	StoreCodeTorBox:     StoreNameTorBox,
 	StoreCodeTorrin:     StoreNameTorrin,
+	StoreCodeWebtor:     StoreNameWebtor,
 }
 
 func (sn StoreName) Code() StoreCode {

--- a/store/webtor/error.go
+++ b/store/webtor/error.go
@@ -1,0 +1,49 @@
+package webtor
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/MunifTanjim/stremthru/core"
+	"github.com/MunifTanjim/stremthru/store"
+	webtorsdk "github.com/webtor-io/api-sdk-go"
+)
+
+var errorCodeByCode = map[string]core.ErrorCode{
+	webtorsdk.CodeBadRequest:      core.ErrorCodeBadRequest,
+	webtorsdk.CodeUnauthorized:    core.ErrorCodeUnauthorized,
+	webtorsdk.CodeForbidden:       core.ErrorCodeForbidden,
+	webtorsdk.CodePaymentRequired: core.ErrorCodePaymentRequired,
+	webtorsdk.CodeNotFound:        core.ErrorCodeNotFound,
+	webtorsdk.CodeConflict:        core.ErrorCodeConflict,
+	webtorsdk.CodeRateLimited:     core.ErrorCodeTooManyRequests,
+	webtorsdk.CodeUnavailable:     core.ErrorCodeServiceUnavailable,
+	webtorsdk.CodeInternal:        core.ErrorCodeInternalServerError,
+	webtorsdk.CodeUpstream:        core.ErrorCodeBadGateway,
+	webtorsdk.CodeUpstreamTimeout: core.ErrorCodeBadGateway,
+}
+
+func UpstreamErrorWithCause(cause error) *core.UpstreamError {
+	err := core.NewUpstreamError("")
+	err.StoreName = string(store.StoreNameWebtor)
+
+	var aerr *webtorsdk.Error
+	if errors.As(cause, &aerr) {
+		err.Msg = aerr.Message
+		if err.Msg == "" {
+			err.Msg = aerr.Code
+		}
+		if code, found := errorCodeByCode[aerr.Code]; found {
+			err.Code = code
+		}
+		err.StatusCode = aerr.HTTPStatus
+		if aerr.RetryAfter > 0 {
+			err.RetryAfter = strconv.Itoa(int(aerr.RetryAfter.Seconds()))
+		}
+		err.UpstreamCause = aerr
+	} else {
+		err.Cause = cause
+	}
+
+	return err
+}

--- a/store/webtor/store.go
+++ b/store/webtor/store.go
@@ -1,0 +1,497 @@
+package webtor
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MunifTanjim/stremthru/core"
+	"github.com/MunifTanjim/stremthru/internal/buddy"
+	"github.com/MunifTanjim/stremthru/internal/config"
+	"github.com/MunifTanjim/stremthru/internal/torrent_stream"
+	"github.com/MunifTanjim/stremthru/internal/util"
+	"github.com/MunifTanjim/stremthru/store"
+	"github.com/MunifTanjim/stremthru/store/stats"
+	webtorsdk "github.com/webtor-io/api-sdk-go"
+	"golang.org/x/sync/errgroup"
+)
+
+// Webtor (https://webtor.io) streams torrents on demand instead of
+// downloading them into cloud storage first, so a stored torrent is
+// immediately playable: AddMagnet/GetMagnet report MagnetStatusDownloaded as
+// soon as the metainfo is known, and GenerateLink resolves a fresh
+// short-lived download URL on every call. The client is the official Go SDK:
+// https://github.com/webtor-io/api-sdk-go
+
+const checkMagnetConcurrency = 8
+
+type StoreClientConfig struct {
+	BaseURL    string // default: https://api.webtor.io/v1
+	APIKey     string
+	HTTPClient *http.Client
+	UserAgent  string
+}
+
+type StoreClient struct {
+	Name       store.StoreName
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	userAgent  string
+}
+
+var _ store.Store = (*StoreClient)(nil)
+
+func NewStoreClient(conf *StoreClientConfig) *StoreClient {
+	if conf == nil {
+		conf = &StoreClientConfig{}
+	}
+	c := &StoreClient{}
+	c.Name = store.StoreNameWebtor
+	c.baseURL = conf.BaseURL
+	c.apiKey = conf.APIKey
+	c.httpClient = conf.HTTPClient
+	if c.httpClient == nil {
+		c.httpClient = config.DefaultHTTPClient
+	}
+	c.userAgent = conf.UserAgent
+	if c.userAgent == "" {
+		c.userAgent = "stremthru"
+	}
+
+	return c
+}
+
+func (c *StoreClient) GetName() store.StoreName {
+	return c.Name
+}
+
+// sdk builds an SDK client bound to the per-request API key.
+func (c *StoreClient) sdk(apiKey string) (*webtorsdk.Client, error) {
+	opts := []webtorsdk.WebUIOption{}
+	if c.baseURL != "" {
+		opts = append(opts, webtorsdk.WithWebUIBaseURL(c.baseURL))
+	}
+	backend, err := webtorsdk.WebUI(apiKey, opts...)
+	if err != nil {
+		serr := core.NewStoreError("failed to create client")
+		serr.StoreName = string(c.Name)
+		serr.Cause = err
+		return nil, serr
+	}
+	client, err := webtorsdk.New(backend,
+		webtorsdk.WithHTTPClient(c.httpClient),
+		webtorsdk.WithUserAgent(c.userAgent),
+	)
+	if err != nil {
+		serr := core.NewStoreError("failed to create client")
+		serr.StoreName = string(c.Name)
+		serr.Cause = err
+		return nil, serr
+	}
+	return client, nil
+}
+
+func (c *StoreClient) GetUser(params *store.GetUserParams) (*store.User, error) {
+	client, err := c.sdk(params.GetAPIKey(c.apiKey))
+	if err != nil {
+		return nil, err
+	}
+	start := time.Now()
+	res, err := client.Profile(params.GetContext())
+	stats.Record(c.Name, "get_user", time.Since(start), err != nil)
+	if err != nil {
+		return nil, UpstreamErrorWithCause(err)
+	}
+	// the API itself answers `payment_required` for free accounts, so a
+	// successful call implies an active paid plan.
+	user := &store.User{
+		Id:                 res.UserID,
+		Email:              res.Email,
+		SubscriptionStatus: store.UserSubscriptionStatusPremium,
+	}
+	return user, nil
+}
+
+// listAllFiles pages through the resource's flat file listing and returns the
+// files as store.MagnetFile with locked links.
+func (c *StoreClient) listAllFiles(ctx context.Context, client *webtorsdk.Client, hash string) ([]store.MagnetFile, error) {
+	files := []store.MagnetFile{}
+	source := string(c.GetName().Code())
+	start := time.Now()
+	for item, err := range client.ListAll(ctx, hash, webtorsdk.ListOptions{}) {
+		if err != nil {
+			stats.Record(c.Name, "list_files", time.Since(start), true)
+			return nil, UpstreamErrorWithCause(err)
+		}
+		if item.Type != webtorsdk.ListTypeFile {
+			continue
+		}
+		files = append(files, store.MagnetFile{
+			Idx:    item.Index,
+			Link:   LockedFileLink("").Create(hash, item.Index),
+			Name:   item.Name,
+			Path:   item.Path,
+			Size:   item.Size,
+			Source: source,
+		})
+	}
+	stats.Record(c.Name, "list_files", time.Since(start), false)
+	return files, nil
+}
+
+func (c *StoreClient) CheckMagnet(params *store.CheckMagnetParams) (*store.CheckMagnetData, error) {
+	magnetByHash := map[string]core.MagnetLink{}
+	hashes := make([]string, len(params.Magnets))
+	for i, m := range params.Magnets {
+		magnet, err := core.ParseMagnetLink(m)
+		if err != nil {
+			return nil, err
+		}
+		magnetByHash[magnet.Hash] = magnet
+		hashes[i] = magnet.Hash
+	}
+
+	foundItemByHash := map[string]store.CheckMagnetDataItem{}
+
+	if data, err := buddy.CheckMagnet(c, hashes, params.GetAPIKey(c.apiKey), params.ClientIP, params.SId, false); err != nil {
+		return nil, err
+	} else {
+		for _, item := range data.Items {
+			foundItemByHash[item.Hash] = item
+		}
+	}
+
+	if params.LocalOnly {
+		data := &store.CheckMagnetData{
+			Items: []store.CheckMagnetDataItem{},
+		}
+
+		for _, hash := range hashes {
+			if item, ok := foundItemByHash[hash]; ok {
+				data.Items = append(data.Items, item)
+			}
+		}
+		return data, nil
+	}
+
+	missingHashes := []string{}
+	for _, hash := range hashes {
+		if _, ok := foundItemByHash[hash]; !ok {
+			missingHashes = append(missingHashes, hash)
+		}
+	}
+
+	client, err := c.sdk(params.GetAPIKey(c.apiKey))
+	if err != nil {
+		return nil, err
+	}
+	ctx := params.GetContext()
+
+	type checkResult struct {
+		res   *webtorsdk.ResourceResponse
+		files []store.MagnetFile
+	}
+	resultByIdx := make([]*checkResult, len(missingHashes))
+	g := errgroup.Group{}
+	g.SetLimit(checkMagnetConcurrency)
+	for i := range missingHashes {
+		g.Go(func() error {
+			hash := missingHashes[i]
+			start := time.Now()
+			res, err := client.Resource(ctx, hash)
+			stats.Record(c.Name, "check_torz", time.Since(start), err != nil)
+			if err != nil {
+				if webtorsdk.IsNotFound(err) {
+					return nil
+				}
+				return UpstreamErrorWithCause(err)
+			}
+			result := &checkResult{res: res}
+			if files, err := c.listAllFiles(ctx, client, hash); err == nil {
+				result.files = files
+			}
+			resultByIdx[i] = result
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	tByHash := map[string]*checkResult{}
+	for i, hash := range missingHashes {
+		if resultByIdx[i] != nil {
+			tByHash[hash] = resultByIdx[i]
+		}
+	}
+
+	data := &store.CheckMagnetData{
+		Items: []store.CheckMagnetDataItem{},
+	}
+	tInfos := []buddy.TorrentInfoInput{}
+	for _, hash := range hashes {
+		if item, ok := foundItemByHash[hash]; ok {
+			data.Items = append(data.Items, item)
+			continue
+		}
+
+		m := magnetByHash[hash]
+		item := store.CheckMagnetDataItem{
+			Hash:   m.Hash,
+			Magnet: m.Link,
+			Status: store.MagnetStatusUnknown,
+			Files:  []store.MagnetFile{},
+		}
+		tInfo := buddy.TorrentInfoInput{
+			Hash: hash,
+		}
+		if t, ok := tByHash[hash]; ok {
+			tInfo.TorrentTitle = t.res.Name
+			tInfo.Size = t.res.Size
+			item.Status = store.MagnetStatusCached
+			item.Name = t.res.Name
+			item.Size = t.res.Size
+			for i := range t.files {
+				f := &t.files[i]
+				tInfo.Files = append(tInfo.Files, torrent_stream.File{
+					Idx:    f.Idx,
+					Path:   f.Path,
+					Name:   f.Name,
+					Size:   f.Size,
+					Source: f.Source,
+				})
+				item.Files = append(item.Files, *f)
+			}
+		}
+		tInfos = append(tInfos, tInfo)
+		data.Items = append(data.Items, item)
+	}
+	go buddy.BulkTrackMagnet(c, tInfos, nil, "", params.GetAPIKey(c.apiKey))
+	return data, nil
+}
+
+type LockedFileLink string
+
+const lockedFileLinkPrefix = "stremthru://store/webtor/"
+
+func (l LockedFileLink) encodeData(hash string, idx int) string {
+	return util.Base64Encode(hash + ":" + strconv.Itoa(idx))
+}
+
+func (l LockedFileLink) decodeData(encoded string) (hash string, idx int, err error) {
+	decoded, err := util.Base64Decode(encoded)
+	if err != nil {
+		return "", 0, err
+	}
+	hash, idxStr, found := strings.Cut(decoded, ":")
+	if !found {
+		return "", 0, core.NewStoreError("invalid link")
+	}
+	idx, err = strconv.Atoi(idxStr)
+	if err != nil {
+		return "", 0, err
+	}
+	return hash, idx, nil
+}
+
+func (l LockedFileLink) Create(hash string, idx int) string {
+	return lockedFileLinkPrefix + l.encodeData(hash, idx)
+}
+
+func (l LockedFileLink) Parse() (hash string, idx int, err error) {
+	encoded := strings.TrimPrefix(string(l), lockedFileLinkPrefix)
+	return l.decodeData(encoded)
+}
+
+func (c *StoreClient) AddMagnet(params *store.AddMagnetParams) (*store.AddMagnetData, error) {
+	client, err := c.sdk(params.GetAPIKey(c.apiKey))
+	if err != nil {
+		return nil, err
+	}
+	ctx := params.GetContext()
+
+	var src webtorsdk.ResourceSource
+	var magnet *core.MagnetLink
+
+	if params.Magnet != "" {
+		m, err := core.ParseMagnetLink(params.Magnet)
+		if err != nil {
+			return nil, err
+		}
+		magnet = &m
+		src = webtorsdk.Magnet(m.RawLink)
+	} else if params.Torrent != nil {
+		f, err := params.Torrent.Open()
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		src = webtorsdk.TorrentReader(f)
+	} else {
+		err := core.NewStoreError("missing magnet or torrent")
+		err.StoreName = string(c.Name)
+		err.StatusCode = http.StatusBadRequest
+		return nil, err
+	}
+
+	start := time.Now()
+	res, err := client.AddResource(ctx, src)
+	stats.Record(c.Name, "add_torz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, UpstreamErrorWithCause(err)
+	}
+	if magnet == nil {
+		m, err := core.ParseMagnetLink(res.ID)
+		if err != nil {
+			return nil, err
+		}
+		magnet = &m
+	}
+
+	start = time.Now()
+	lib, err := client.LibraryAdd(ctx, res.ID)
+	stats.Record(c.Name, "add_library", time.Since(start), err != nil)
+	if err != nil {
+		return nil, UpstreamErrorWithCause(err)
+	}
+
+	data := &store.AddMagnetData{
+		Id:      res.ID,
+		Hash:    res.ID,
+		Magnet:  magnet.Link,
+		Name:    res.Name,
+		Size:    res.Size,
+		Status:  store.MagnetStatusDownloaded,
+		Files:   []store.MagnetFile{},
+		AddedAt: lib.AddedAt,
+	}
+
+	files, err := c.listAllFiles(ctx, client, res.ID)
+	if err != nil {
+		return nil, err
+	}
+	data.Files = files
+
+	return data, nil
+}
+
+func (c *StoreClient) GetMagnet(params *store.GetMagnetParams) (*store.GetMagnetData, error) {
+	client, err := c.sdk(params.GetAPIKey(c.apiKey))
+	if err != nil {
+		return nil, err
+	}
+	ctx := params.GetContext()
+
+	id := strings.ToLower(params.Id)
+	start := time.Now()
+	res, err := client.Resource(ctx, id)
+	stats.Record(c.Name, "get_torz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, UpstreamErrorWithCause(err)
+	}
+
+	data := &store.GetMagnetData{
+		Id:      res.ID,
+		Hash:    res.ID,
+		Name:    res.Name,
+		Size:    res.Size,
+		Status:  store.MagnetStatusDownloaded,
+		Files:   []store.MagnetFile{},
+		AddedAt: time.Now(),
+	}
+
+	if lib, err := client.LibraryGet(ctx, id); err == nil {
+		data.AddedAt = lib.AddedAt
+	}
+
+	files, err := c.listAllFiles(ctx, client, res.ID)
+	if err != nil {
+		return nil, err
+	}
+	data.Files = files
+
+	return data, nil
+}
+
+func (c *StoreClient) ListMagnets(params *store.ListMagnetsParams) (*store.ListMagnetsData, error) {
+	client, err := c.sdk(params.GetAPIKey(c.apiKey))
+	if err != nil {
+		return nil, err
+	}
+	start := time.Now()
+	res, err := client.LibraryList(params.GetContext(), webtorsdk.LibraryListOptions{
+		Limit:  params.Limit,
+		Offset: params.Offset,
+	})
+	stats.Record(c.Name, "list_torz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, UpstreamErrorWithCause(err)
+	}
+
+	data := &store.ListMagnetsData{
+		Items:      []store.ListMagnetsDataItem{},
+		TotalItems: res.Count,
+	}
+	for i := range res.Items {
+		item := &res.Items[i]
+		data.Items = append(data.Items, store.ListMagnetsDataItem{
+			Id:      item.ResourceID,
+			Hash:    item.ResourceID,
+			Name:    item.Name,
+			Size:    item.Size,
+			Status:  store.MagnetStatusDownloaded,
+			AddedAt: item.AddedAt,
+		})
+	}
+	return data, nil
+}
+
+func (c *StoreClient) RemoveMagnet(params *store.RemoveMagnetParams) (*store.RemoveMagnetData, error) {
+	client, err := c.sdk(params.GetAPIKey(c.apiKey))
+	if err != nil {
+		return nil, err
+	}
+	id := strings.ToLower(params.Id)
+	start := time.Now()
+	err = client.LibraryRemove(params.GetContext(), id)
+	stats.Record(c.Name, "remove_torz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, UpstreamErrorWithCause(err)
+	}
+	return &store.RemoveMagnetData{Id: id}, nil
+}
+
+func (c *StoreClient) GenerateLink(params *store.GenerateLinkParams) (*store.GenerateLinkData, error) {
+	hash, idx, err := LockedFileLink(params.Link).Parse()
+	if err != nil {
+		aerr := core.NewAPIError("invalid link")
+		aerr.StatusCode = http.StatusBadRequest
+		aerr.Cause = err
+		return nil, aerr
+	}
+
+	client, err := c.sdk(params.GetAPIKey(c.apiKey))
+	if err != nil {
+		return nil, err
+	}
+
+	start := time.Now()
+	res, err := client.Export(params.GetContext(), hash, strconv.Itoa(idx), webtorsdk.ExportOptions{
+		Types: []webtorsdk.ExportType{webtorsdk.ExportTypeDownload},
+	})
+	stats.Record(c.Name, "generate_torz_link", time.Since(start), err != nil)
+	if err != nil {
+		return nil, UpstreamErrorWithCause(err)
+	}
+	link, ok := res.DownloadURL()
+	if !ok {
+		serr := core.NewStoreError("missing download export")
+		serr.StoreName = string(c.Name)
+		serr.StatusCode = http.StatusNotFound
+		return nil, serr
+	}
+	return &store.GenerateLinkData{Link: link}, nil
+}


### PR DESCRIPTION
Adds [Webtor](https://webtor.io) as a supported store.

Webtor streams torrents on demand instead of downloading them into cloud storage first, so a stored torrent is immediately playable: `AddMagnet`/`GetMagnet` report `downloaded` as soon as the metainfo is known, and `GenerateLink` resolves a fresh short-lived download URL on every call (locked links, same pattern as TorBox). The client is the official Go SDK ([webtor-io/api-sdk-go](https://github.com/webtor-io/api-sdk-go)).

- New `store/webtor` package implementing the `Store` interface
- Registered name `webtor` / code `wt` in `store/store.go`, the `shared` factory, and the addon layer (store selectors, configure hints, catalog logo)
- `CheckMagnet` consults the buddy cache first, then checks the resource store per hash (bounded concurrency) and feeds results back via `BulkTrackMagnet`
- API errors are normalized from the SDK's typed errors (including `Retry-After` on rate limits)
- Docs + README updated

Tested end-to-end against the live API through a local StremThru instance: `user`, `magnets/check`, add/get/list/remove, `link/generate` + ranged download of the resulting URL.

Happy to adjust naming/scope, or wire up an env-configurable base URL for self-hosted Webtor instances in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)