### PR TITLE
feat(store): add newz support for Torrin

### DIFF
--- a/internal/stremio/shared/store.go
+++ b/internal/stremio/shared/store.go
@@ -71,6 +71,7 @@ func GetStoreCodeOptionsForNewz() []configure.ConfigOption {
 	options := []configure.ConfigOption{
 		{Value: "", Label: "StremThru"},
 		{Value: "tb", Label: "TorBox"},
+		{Value: "ti", Label: "Torrin"},
 	}
 	if config.IsPublicInstance {
 		options[0].Disabled = true
@@ -80,6 +81,19 @@ func GetStoreCodeOptionsForNewz() []configure.ConfigOption {
 }
 
 func WaitForNewzStatus(ctx *Ctx, data *store.GetNewzData, status store.NewzStatus, maxRetry int, retryInterval time.Duration) (*store.GetNewzData, error) {
+	if data.Status == status {
+		params := &store.GetNewzParams{
+			Id:       data.Id,
+			ClientIP: ctx.ClientIP,
+		}
+		params.APIKey = ctx.StoreAuthToken
+		newz, err := ctx.Store.(store.NewzStore).GetNewz(params)
+		if err != nil {
+			return data, err
+		}
+		return newz, nil
+	}
+
 	retry := 0
 	for data.Status != status && retry < maxRetry {
 		params := &store.GetNewzParams{

--- a/internal/stremio/store/catalog.go
+++ b/internal/stremio/store/catalog.go
@@ -53,7 +53,7 @@ func getUsenetCatalogItems(s store.Store, storeToken string, clientIp string, id
 	idPrefix := getIdPrefix(idStoreCode)
 
 	switch s.GetName() {
-	case store.StoreNameStremThru:
+	case store.StoreNameStremThru, store.StoreNameTorrin:
 		if newzStore, ok := s.(store.NewzStore); ok {
 			params := &store.ListNewzParams{
 				ClientIP: clientIp,

--- a/internal/stremio/store/meta.go
+++ b/internal/stremio/store/meta.go
@@ -247,7 +247,7 @@ type contentInfo struct {
 func getStoreContentInfo(s store.Store, storeToken string, id string, clientIp string, idr *ParsedId) (*contentInfo, error) {
 	if idr.isUsenet {
 		switch s.GetName() {
-		case store.StoreNameStremThru:
+		case store.StoreNameStremThru, store.StoreNameTorrin:
 			newzStore, ok := s.(store.NewzStore)
 			if !ok {
 				return nil, nil

--- a/internal/stremio/store/usenet/usenet.go
+++ b/internal/stremio/store/usenet/usenet.go
@@ -20,7 +20,7 @@ var tbClient = torbox.NewAPIClient(&torbox.APIClientConfig{
 
 func IsSupported(storeCode store.StoreCode) bool {
 	switch storeCode {
-	case store.StoreCodeTorBox:
+	case store.StoreCodeTorBox, store.StoreCodeTorrin:
 		return true
 	default:
 		return false

--- a/store/torrin/store.go
+++ b/store/torrin/store.go
@@ -1,9 +1,13 @@
 package torrin
 
 import (
+	"errors"
+	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/MunifTanjim/stremthru/core"
@@ -27,7 +31,10 @@ type StoreClient struct {
 	client *APIClient
 }
 
-var _ store.Store = (*StoreClient)(nil)
+var (
+	_ store.Store     = (*StoreClient)(nil)
+	_ store.NewzStore = (*StoreClient)(nil)
+)
 
 func NewStoreClient(config *StoreClientConfig) *StoreClient {
 	if config == nil {
@@ -78,6 +85,15 @@ func (s *StoreClient) CheckMagnet(params *store.CheckMagnetParams) (*store.Check
 	if err != nil {
 		return nil, err
 	}
+	for itemIndex := range response.Data.Items {
+		item := &response.Data.Items[itemIndex]
+		for fileIndex := range item.Files {
+			file := &item.Files[fileIndex]
+			if isSignedLink(file.Link) {
+				file.Link = generateFakeLink(item.Hash, file.Idx)
+			}
+		}
+	}
 	return &response.Data, nil
 }
 
@@ -110,18 +126,20 @@ func (s *StoreClient) AddMagnet(params *store.AddMagnetParams) (*store.AddMagnet
 }
 
 func (s *StoreClient) GetMagnet(params *store.GetMagnetParams) (*store.GetMagnetData, error) {
-	ctx := params.Ctx
-	if params.ClientIP != "" {
-		ctx.Query = &url.Values{"client_ip": []string{params.ClientIP}}
-	}
-	response := &Response[store.GetMagnetData]{}
-	start := time.Now()
-	_, err := s.client.Request(http.MethodGet, "/v0/store/magnets/"+url.PathEscape(params.Id), &ctx, response)
-	stats.Record(s.Name, "get_torz", time.Since(start), err != nil)
+	data, err := s.getRawMagnet(params)
 	if err != nil {
 		return nil, err
 	}
-	return &response.Data, nil
+	// create placeholder link that can later be used to create presigned link
+	// this is important for link stability, as Torrin returns signed link by
+	// default
+	for i := range data.Files {
+		file := &data.Files[i]
+		if isSignedLink(file.Link) {
+			file.Link = generateFakeLink(data.Id, file.Idx)
+		}
+	}
+	return data, nil
 }
 
 func (s *StoreClient) ListMagnets(params *store.ListMagnetsParams) (*store.ListMagnetsData, error) {
@@ -163,6 +181,24 @@ func (s *StoreClient) RemoveMagnet(params *store.RemoveMagnetParams) (*store.Rem
 }
 
 func (s *StoreClient) GenerateLink(params *store.GenerateLinkParams) (*store.GenerateLinkData, error) {
+	if parsedId, success := parseIdFromFakeLink(params.Link); success {
+		data, err := s.getRawMagnet(&store.GetMagnetParams{
+			Ctx:      params.Ctx,
+			Id:       parsedId.Id,
+			ClientIP: params.ClientIP,
+		})
+		if err != nil {
+			return nil, err
+		}
+		files := data.Files
+		if len(files) <= parsedId.Idx {
+			return nil, errors.New("No matching files found")
+		}
+		return &store.GenerateLinkData{
+			Link: data.Files[parsedId.Idx].Link,
+		}, nil
+	}
+
 	ctx := params.Ctx
 	ctx.JSON = map[string]string{"link": params.Link}
 	if params.ClientIP != "" {
@@ -172,6 +208,207 @@ func (s *StoreClient) GenerateLink(params *store.GenerateLinkParams) (*store.Gen
 	start := time.Now()
 	_, err := s.client.Request(http.MethodPost, "/v0/store/link/generate", &ctx, response)
 	stats.Record(s.Name, "generate_torz_link", time.Since(start), err != nil)
+	if err != nil {
+		return nil, err
+	}
+	return &response.Data, nil
+}
+
+func (s *StoreClient) CheckNewz(params *store.CheckNewzParams) (*store.CheckNewzData, error) {
+	ctx := params.Ctx
+	query := url.Values{"hash": params.Hashes}
+	ctx.Query = &query
+	response := &Response[store.CheckNewzData]{}
+	start := time.Now()
+	_, err := s.client.Request(http.MethodGet, "/v0/store/newz/check", &ctx, response)
+	stats.Record(s.Name, "check_newz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, err
+	}
+	for itemIndex := range response.Data.Items {
+		item := &response.Data.Items[itemIndex]
+		for fileIndex := range item.Files {
+			file := &item.Files[fileIndex]
+			if isSignedLink(file.Link) {
+				file.Link = generateFakeLink(item.Hash, file.Idx)
+			}
+		}
+	}
+	return &response.Data, nil
+}
+
+func (s *StoreClient) AddNewz(params *store.AddNewzParams) (*store.AddNewzData, error) {
+	ctx := params.Ctx
+	if params.ClientIP != "" {
+		ctx.Query = &url.Values{"client_ip": []string{params.ClientIP}}
+	}
+	if params.File != nil {
+		form := multipart.Form{}
+		form.File = make(map[string][]*multipart.FileHeader, 1)
+		form.File["file"] = []*multipart.FileHeader{params.File}
+		ctx.MultiPartForm = &form
+	} else if params.Link != "" {
+		ctx.JSON = map[string]string{"link": params.Link}
+	} else {
+		return nil, errors.New("File or link required")
+	}
+	response := &Response[store.AddNewzData]{}
+	start := time.Now()
+	_, err := s.client.Request(http.MethodPost, "/v0/store/newz", &ctx, response)
+	stats.Record(s.Name, "add_newz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, err
+	}
+	data := &response.Data
+	return data, nil
+}
+
+func (s *StoreClient) GetNewz(params *store.GetNewzParams) (*store.GetNewzData, error) {
+	data, err := s.getRawNewz(params)
+	if err != nil {
+		return nil, err
+	}
+	// create placeholder link that can later be used to create presigned link
+	// this is important for link stability, as Torrin returns signed link by
+	// default
+	for i := range data.Files {
+		file := &data.Files[i]
+		if isSignedLink(file.Link) {
+			file.Link = generateFakeLink(data.Id, file.Idx)
+		}
+	}
+	return data, nil
+}
+
+func (s *StoreClient) ListNewz(params *store.ListNewzParams) (*store.ListNewzData, error) {
+	ctx := params.Ctx
+	query := url.Values{}
+	if params.Limit > 0 {
+		query.Set("limit", strconv.Itoa(params.Limit))
+	}
+	if params.Offset > 0 {
+		query.Set("offset", strconv.Itoa(params.Offset))
+	}
+	if params.ClientIP != "" {
+		query.Set("client_ip", params.ClientIP)
+	}
+	ctx.Query = &query
+	response := &Response[store.ListNewzData]{}
+	start := time.Now()
+	_, err := s.client.Request(http.MethodGet, "/v0/store/newz", &ctx, response)
+	stats.Record(s.Name, "list_newz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, err
+	}
+	return &response.Data, nil
+}
+
+func (s *StoreClient) RemoveNewz(params *store.RemoveNewzParams) (*store.RemoveNewzData, error) {
+	ctx := params.Ctx
+	response := &Response[store.RemoveNewzData]{}
+	start := time.Now()
+	_, err := s.client.Request(http.MethodDelete, "/v0/store/newz/"+url.PathEscape(params.Id), &ctx, response)
+	stats.Record(s.Name, "remove_newz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, err
+	}
+	if response.Data.Id == "" {
+		response.Data.Id = params.Id
+	}
+	return &response.Data, nil
+}
+
+func (s *StoreClient) GenerateNewzLink(params *store.GenerateNewzLinkParams) (*store.GenerateNewzLinkData, error) {
+	if parsedId, success := parseIdFromFakeLink(params.Link); success {
+		data, err := s.getRawNewz(&store.GetNewzParams{
+			Ctx:      params.Ctx,
+			Id:       parsedId.Id,
+			ClientIP: params.ClientIP,
+		})
+		if err != nil {
+			return nil, err
+		}
+		files := data.Files
+		if len(files) <= parsedId.Idx {
+			return nil, errors.New("No matching files found")
+		}
+		return &store.GenerateNewzLinkData{
+			Link: data.Files[parsedId.Idx].Link,
+		}, nil
+	}
+
+	ctx := params.Ctx
+	if params.ClientIP != "" {
+		ctx.Query = &url.Values{"client_ip": []string{params.ClientIP}}
+	}
+	ctx.JSON = map[string]string{"link": params.Link}
+	response := &Response[store.GenerateNewzLinkData]{}
+	start := time.Now()
+	_, err := s.client.Request(http.MethodPost, "/v0/store/newz/link/generate", &ctx, response)
+	stats.Record(s.Name, "generate_newz_link", time.Since(start), err != nil)
+	if err != nil {
+		return nil, err
+	}
+	return &response.Data, nil
+}
+
+type parsedId struct {
+	Id  string
+	Idx int
+}
+
+func isSignedLink(link string) bool {
+	return strings.Contains(link, "expires=")
+}
+
+func generateFakeLink(id string, idx int) string {
+	return fmt.Sprintf("torrin://file-by-id/%s/%d", id, idx)
+}
+
+func parseIdFromFakeLink(link string) (*parsedId, bool) {
+	idAndIdxStr, found := strings.CutPrefix(link, "torrin://file-by-id/")
+	if !found {
+		return nil, false
+	}
+
+	idAndIdx := strings.Split(idAndIdxStr, "/")
+	if len(idAndIdx) != 2 {
+		return nil, false
+	}
+
+	id := idAndIdx[0]
+	idx, err := strconv.Atoi(idAndIdx[1])
+	if err != nil {
+		return nil, false
+	}
+
+	return &parsedId{Id: id, Idx: idx}, true
+}
+
+func (s *StoreClient) getRawMagnet(params *store.GetMagnetParams) (*store.GetMagnetData, error) {
+	ctx := params.Ctx
+	if params.ClientIP != "" {
+		ctx.Query = &url.Values{"client_ip": []string{params.ClientIP}}
+	}
+	response := &Response[store.GetMagnetData]{}
+	start := time.Now()
+	_, err := s.client.Request(http.MethodGet, "/v0/store/magnets/"+url.PathEscape(params.Id), &ctx, response)
+	stats.Record(s.Name, "get_torz", time.Since(start), err != nil)
+	if err != nil {
+		return nil, err
+	}
+	return &response.Data, nil
+}
+
+func (s *StoreClient) getRawNewz(params *store.GetNewzParams) (*store.GetNewzData, error) {
+	ctx := params.Ctx
+	if params.ClientIP != "" {
+		ctx.Query = &url.Values{"client_ip": []string{params.ClientIP}}
+	}
+	response := &Response[store.GetNewzData]{}
+	start := time.Now()
+	_, err := s.client.Request(http.MethodGet, "/v0/store/newz/"+url.PathEscape(params.Id), &ctx, response)
+	stats.Record(s.Name, "get_newz", time.Since(start), err != nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds Newz support to Torrin store. Supports adding by link or nzb file, link resolving.
Torrin always returns signed URLs and that was causing issues in playback module that compares URLs, so fake `torrin://` URLs  were introduced that are resolved to signed ones on demand. When Newz stremio addon is combined with some indexer, it results in playable streams.